### PR TITLE
Add compatibility for KF6

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,0 +1,19 @@
+{
+    "KPackageStructure": "Plasma/LookAndFeel",
+    "KPlugin": {
+        "Authors": [
+            {
+                "Email": "adhemarks@gmail.com",
+                "Name": "adhe"
+            }
+        ],
+        "Category": "",
+        "Description": "QuarksSplash for Plasma KDE",
+        "Id": "QuarksSplashDarker",
+        "License": "MIT",
+        "Name": "QuarksSplashDarker",
+        "Website": "https://github.com/igflavius/quarkssplashdarker"
+    },
+    "Keywords": "Desktop;Workspace;Appearance;Look and Feel;Logout;Lock;Suspend;Shutdown;Hibernate;",
+    "X-Plasma-APIVersion": "2"
+}


### PR DESCRIPTION
Starting with KF6 a manifest.desktop is required, it serves the same function as manifest.desktop but having both files should make it work with KF6 without losing compatibility with previous versions. The change is straightforward and trivial.